### PR TITLE
Revert "Bump nanoid from 3.1.22 to 3.3.4"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,15 +7,15 @@
     "": {
       "version": "4.0.0",
       "dependencies": {
-        "@material-ui/core": "*",
+        "@material-ui/core": "latest",
         "@material-ui/icons": "^4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.57",
-        "clsx": "*",
-        "react": "*",
-        "react-dom": "*",
+        "clsx": "latest",
+        "react": "latest",
+        "react-dom": "latest",
         "react-draggable": "^4.4.3",
         "react-router-dom": "^5.2.0",
-        "react-scripts": "*"
+        "react-scripts": "latest"
       },
       "devDependencies": {
         "eslint": "^7.26.0",
@@ -13478,9 +13478,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.1.22",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
+      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -32215,9 +32215,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+      "version": "3.1.22",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
+      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ=="
     },
     "nanomatch": {
       "version": "1.2.13",


### PR DESCRIPTION
## what
Reverts MaximizedOwl/among-status#57

## why
- CI error
[Merge pull request #57 from MaximizedOwl/dependabot/npm_and_yarn/nano…](https://github.com/MaximizedOwl/among-status/actions/runs/4815460557)